### PR TITLE
manifest.json: Fix version format

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.1b3",
+  "version": "0.2.1.3",
   "name": "Smart HTTPS with Mixed Content Upgrade",
   "manifest_version": 2,
   "short_name": "smarthttps",


### PR DESCRIPTION
Chrome·ium requires version to be formatted using 1-4 dot-separated integers.